### PR TITLE
Added song title modifier for playlist transfers

### DIFF
--- a/src/components/PlaylistInfo.js
+++ b/src/components/PlaylistInfo.js
@@ -119,6 +119,12 @@ const PlaylistInfo = ({ playlistId }) => {
               ...spotifySongs,
               response.data.tracks.items[0],
             ]);
+          } else {
+            if (songTitle != '') {
+              let tempTitle = songTitle;
+              tempTitle = tempTitle.substr(0, tempTitle.lastIndexOf(' '));
+              setSongTitle(tempTitle);
+            }
           }
         })
         .catch((error) => {
@@ -230,7 +236,7 @@ const PlaylistInfo = ({ playlistId }) => {
               <div className='line'></div>
               <div className='right'>
                 <div className='header'>
-                  <h2 className='lbl'>Detected Songs</h2>
+                  <h2 className='lbl'>{spotifySongs.length} Detected Songs</h2>
                   <input
                     type='button'
                     value={selectedAll ? 'Unselect all' : 'Select all'}

--- a/src/utils/formats.js
+++ b/src/utils/formats.js
@@ -25,6 +25,7 @@ export const formatTitle = (title) => {
     'live performance',
     'live session',
     'live in',
+    'ft',
     'feat',
     'featuring',
     '\\.',


### PR DESCRIPTION
-Implemented song title string modifier when no result is found into playlist transfers (previously only for single song transfers).
-Added a string into invalidWords for title formatting.
-Added display for the number of songs detected in PlaylistInfo component.